### PR TITLE
Add option for cors

### DIFF
--- a/generators/javascript/index.js
+++ b/generators/javascript/index.js
@@ -86,6 +86,12 @@ module.exports = class extends Generator {
         default: "sql"
       },
       {
+        type: "confirm",
+        name: "cors",
+        message: "Would you like to install CORS?",
+        default: true
+      },
+      {
         type: "list",
         name: "specification",
         message: `OpenAPI spec version`,
@@ -129,6 +135,7 @@ module.exports = class extends Generator {
       this.apiRoot = r.apiRoot ? r.apiRoot.replace(/^\/?/, "/") : this.apiRoot;
       this.authentication = r.authentication;
       this.database = r.database;
+      this.cors = r.cors;
       this.linter = r.linter;
       this.specification = r.specification;
     });
@@ -235,6 +242,7 @@ module.exports = class extends Generator {
         apiRoot: this.apiRoot,
         authentication: this.authentication,
         database: this.database,
+        cors: this.cors,
         linter: this.linter,
         specification: this.specification
       };

--- a/generators/javascript/templates/backend/package.json
+++ b/generators/javascript/templates/backend/package.json
@@ -18,6 +18,9 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "pino": "^6.10.0",
+    <% if(cors) { %>
+    "cors": "^2.8.5",
+    <% } %>
     <% if (database === 'mongo') { %>
     "mongoose": "^5.11.17",
     <% } else if (database === 'sql') { %>

--- a/generators/javascript/templates/backend/server/common/server.js
+++ b/generators/javascript/templates/backend/server/common/server.js
@@ -3,6 +3,9 @@ import Express from 'express';
 import session from 'express-session';
 import cookieParser from 'cookie-parser';
 <% } %>
+<% if(cors) { %>
+import cors from 'cors';
+<% } %>
 import * as path from 'path';
 import * as bodyParser from 'body-parser';
 import * as http from 'http';
@@ -51,6 +54,9 @@ export default class ExpressServer {
         ignorePaths: /.*\/spec(\/|$)/,
       })
     );
+<% } %>
+<% if(cors) { %>
+    app.use(cors());
 <% } %>
   }
 


### PR DESCRIPTION
## Task

REST APIs usually have CORS enabled, so it would be nice to add it into the template. Resolves #11.

## Solution

Give the user an option to add CORS to their backend app.

## Type of Change
<!-- Put an x in boxes below to select an option -->
- [x] New feature
- [ ] Feature update/enhancement
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Other: _Please describe_

## Screenshot(s)

_Include any screenshots that can assist the person reviewing the PR._
![image](https://user-images.githubusercontent.com/43517435/108479621-f6cccd80-72bb-11eb-97cf-ed90e516a1ca.png)
