### PR TITLE
removed package-lock.json file from template generation

### DIFF
--- a/generators/django/index.js
+++ b/generators/django/index.js
@@ -159,7 +159,6 @@ module.exports = class extends Generator {
       files.push("django-react/backend/requirements.txt");
       files.push("django-react/frontend/public/");
       files.push("django-react/frontend/src/");
-      files.push("django-react/frontend/package-lock.json");
       files.push("django-react/frontend/package.json");
       files.push("django-react/README.MD")
       if (this.docker == "yes") {


### PR DESCRIPTION
Bug fix for generating django react template

## Task

Removed package-lock.json from template generation, will be generated when npm install is run for react frontend.

## Solution

Removed package-lock.json from template generation

## Type of Change
<!-- Put an x in boxes below to select an option -->
- [ ] New feature
- [ ] Feature update/enhancement
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Other: _Please describe_
