### PR TITLE
chore : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/generators/django/templates/django-react/backend/Dockerfile
+++ b/generators/django/templates/django-react/backend/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir /backend
 WORKDIR /backend
 COPY requirements.txt /backend/
 EXPOSE 8000
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 COPY . /backend/
 WORKDIR /backend/api
 RUN python manage.py makemigrations

--- a/generators/django/templates/django/mysite/Dockerfile
+++ b/generators/django/templates/django/mysite/Dockerfile
@@ -5,7 +5,7 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /generators/django/templates/django/mysite
 
 COPY requirements.txt /generators/django/templates/django/mysite
-RUN pip3 install --upgrade pip -r requirements.txt
+RUN pip3 install --no-cache-dir --upgrade pip -r requirements.txt
 
 COPY . /generators/django/templates/django/mysite
 


### PR DESCRIPTION
## Task
## Solution

using --no-cache-dir flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>

## Type of Change
<!-- Put an x in boxes below to select an option -->
- [ ] New feature
- [x] Feature update/enhancement
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Other: _Please describe_

## Screenshot(s)

_Include any screenshots that can assist the person reviewing the PR._
