### PR TITLE
feat: build and run from Docker Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ghcr.io/container-projects/base-docker-images:node-12-npm-yo-latest
+USER root
+RUN  mkdir /code/
+COPY . /code/.
+RUN npm i -g /code/.
+RUN \
+  # configure the "yo" user
+  groupadd yo && \
+  useradd yo -s /bin/bash -m -g yo -G sudo && \
+  echo yo:yo |chpasswd 
+RUN mkdir /home/yo/app
+USER yo
+ENV PATH $PATH:/usr/bin
+WORKDIR "/home/yo/app"
+VOLUME ["/home/yo/app"]
+CMD ["yo"]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,34 @@ yo front-to-back:django
 
 Answer a few simple questions and configure your app in a few seconds!
 
+## Using Docker
+
+
+Build the Docker images:
+
+```bash
+docker build -t generator-front-to-back:latest .
+```
+
+Make a folder where you want to generate the Service:
+
+```bash
+mkdir service
+cd service
+```
+
+Run the generator from image to generate service:
+
+```bash
+docker run -it --rm -v $PWD:/home/yo/app generator-front-to-back
+```
+
+Run and attach interactive shell to the generator docker container to work from inside the running container:
+
+```bash
+docker run -it --rm -v $PWD:/home/yo/app generator-front-to-back /bin/bash
+```
+
 ## Features
 
 ### Javascript


### PR DESCRIPTION
## Task
## Solution

Build and run the generator from docker image support added.

The main aim and motivation behind doing this is, because
of a no. of different yeoman generators are there,
which are compatible and works with the different version of yeoman generators
and also might be incompatible with other yeoman generators or versions of yeoman.

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>

## Type of Change
<!-- Put an x in boxes below to select an option -->
- [x] New feature
- [ ] Feature update/enhancement
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Other: _Please describe_

## Screenshot(s)

_Include any screenshots that can assist the person reviewing the PR._
